### PR TITLE
Don't set stepper to NULL if empty result set is returned.

### DIFF
--- a/R/paginate.R
+++ b/R/paginate.R
@@ -44,7 +44,7 @@ paginate <- function(url, head = FALSE, limit = 10000, verbose = NULL) {
           #
           stepper <- progressr::progressor(steps = count_page, auto_finish = FALSE)
         } else {
-          stepper <- NULL
+          break
         }
       }
 


### PR DESCRIPTION
I'm not sure if this `break` statement will ever be run, but it does seem to fix the problem when the `result_count` is NULL.